### PR TITLE
src/bkg fitting and background fitting in photon_toa

### DIFF
--- a/scripts/photon_fit.py
+++ b/scripts/photon_fit.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# Program: photon_toa.py
+# Authors: Paul S. Ray <paul.ray@nrl.navy.mil>
+#          Matthew Kerr <matthew.kerr@gmail.com>
+# Description:
+# Reads a FITS file of photon event times (from NICER or another X-ray mission)
+# and generates TOAs from the unbined times using a pulsar timing model
+# and an analytic template. The TOAs can be output them in Tempo2 format.
+from __future__ import division, print_function
+import os,sys
+import argparse
+import numpy as np
+from astropy import log
+#import astropy.units as u
+import astropy.io.fits as pyfits
+from pint.eventstats import hmw, hm, h2sig
+from pint.templates.lctemplate import LCTemplate,prim_io
+from pint.templates import lcfitters
+import cPickle
+
+desc="""Perform a template fit using a stored phase column and print source and background properties."""
+
+parser=argparse.ArgumentParser(description=desc)
+parser.add_argument("eventname",help="FITS file to read events from")
+parser.add_argument("templatename",help="Name of file to read template from")
+parser.add_argument("--phasecol",help="FITS column to use for pulse phase.", default="PULSE_PHASE")
+
+## Parse arguments
+args = parser.parse_args()
+
+# Load Template objects
+try:
+    template = cPickle.load(file(args.templatename))
+except:
+    primitives,norms = prim_io(args.templatename)
+    template = LCTemplate(primitives,norms)
+
+log.info("Template properties: \n{0}".format(str(template)))
+
+# load up events and exposure information
+f = pyfits.open(args.eventname)
+phases = f[1].data.field(args.phasecol)
+try:
+    exposure = f[1].header['exposure']
+except:
+    exposure = 0
+
+
+h = float(hm(phases))
+log.info("Htest : {0:.2f} ({1:.2f} sigma)".format(h,h2sig(h)))
+
+# make sure template shape is fixed
+lcf = lcfitters.LCFitter(template,phases)
+for prim in lcf.template.primitives:
+    prim.free[:] = False
+
+# do iterative fit of position and background
+for i in xrange(2):
+    lcf.fit_position(unbinned=False)
+    lcf.fit_background(unbinned=False)
+
+# get exposure information
+try:
+    f = pyfits.open(args.eventname)
+    f.close()
+except:
+    exposure = 0
+
+# Use PINT's TOA writer to save the TOA
+nsrc = lcf.template.norm()*len(lcf.phases)
+nbkg = (1-lcf.template.norm())*len(lcf.phases)
+log.info("Exposure = {0:.2f} s, Nsrc = {1}, Nbkg = {2}".format(exposure,nsrc,nbkg))
+log.info("Src rate = {0:.2f} c/s, Bkg rate = {1:.2f} c/s".format(nsrc/exposure, nbkg/exposure))


### PR DESCRIPTION
A new script that will simply use existing PULSE_PHASE column and spit out source/background estimates.

Some improvements to photon_toa to fit the background level and choose unbinned/binned fitting.

Can use pickled LCTemplates in both.  (Suggest updating itemplate to spit out pickles.)