### PR TITLE
--merge option added

### DIFF
--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -277,7 +277,7 @@ for obsdir in args.indirs:
 if args.merge & (len(all_evfiles)>1) :
     
     # Make directory for working files and output
-    pipedir = "merged"
+    pipedir = "merged_{0}".format(args.outdir)
     if not os.path.exists(pipedir):
         os.makedirs(pipedir)
     log.info('Merging all ObsIDs into single event file with niextract-event')

--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -303,11 +303,10 @@ if args.merge & (len(all_evfiles)>1) :
     cmd = ["nicerql.py", "--save",
            "--sci", outname, "--lcbinsize", "4.0",
            "--basename", path.splitext(outname)[0]]
-    ## -- NOT TESTED --
     if args.par is not None:
-        cmd.append("--par")
-        cmd.append("{0}".format(args.par))
-    ## ----------------    
+        log.info('The use of par files requires a merged orbit file -- not implemented yet')
+        #cmd.append("--par")
+        #cmd.append("{0}".format(args.par))
     runcmd(cmd)
 
     # Extract simple PHA file and light curve


### PR DESCRIPTION
When more than one ObsID is provided (and more than one obsID with non-zero
GTI), adding the—merge option will create a single merged event list (with a nicerql plot), a single lightcurve, and a single spectra.