### PR TITLE
Adding ObsID merger Option

### DIFF
--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -62,6 +62,7 @@ parser.add_argument("--eventshootrate",help="Gets over/undershoot rates from the
 parser.add_argument("--interactive", help= "TEST FOR INTERACTIVE LC", action = 'store_true')
 parser.add_argument("--readovs", help = "Filters events with overshoot > input number", nargs = '*', type = float, default = None)
 parser.add_argument("--gtirows",help="Select GTI rows", nargs = '*', type=int, default=None)
+parser.add_argument("--merge", help="when using a merged file, the OBSID keyword in header is updated (for plotting purposes)", action='store_true')
 args = parser.parse_args()
 
 #------------------------------Getting the data and concatenating------------------------------
@@ -259,6 +260,10 @@ filttable = etable[idx]
 filttable.meta['FILT_STR'] = filt_str
 etable.meta['FILT_STR'] = filt_str
 
+# Replace ObsID keyword (if it is a merged table)
+if args.merge:
+    log.info('Overwriting the header of outfile {0} by "{1}"'.format(path.basename(args.infiles[0]),path.dirname(args.infiles[0])))
+    filttable.meta['OBS_ID'] = path.dirname(basename)
 
 # Add Time column with astropy Time for ease of use and for PINT TOAs
 if args.par is not None:

--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -283,7 +283,7 @@ if args.merge and (len(all_evfiles)>1) :
 
     ## The list of event files all_evfiles is created in the loop above
     all_evfiles.sort()
-    log.info('Cleaned Event Files to Merge: {0}'.format("\n" + "    \n".join(all_evfiles)))
+    log.info('Cleaned Event Files to Merge: {0}'.format("\n      " + "\n      ".join(all_evfiles)))
 
     # Build input file for niextract-events
     evlistname=path.join(pipedir,'evfiles.txt')
@@ -299,11 +299,11 @@ if args.merge and (len(all_evfiles)>1) :
     runcmd(cmd)
 
     # Make final merged clean plot
-    cmd = ["nicerql.py", "--save",
+    cmd = ["nicerql.py", "--save", "--merge",
            "--sci", outname, "--lcbinsize", "4.0",
            "--basename", path.splitext(outname)[0]]
     if args.par is not None:
-        log.info('The use of par files requires a merged orbit file -- not implemented yet')
+        log.warning('The use of par files requires a merged orbit file -- not implemented yet')
         #cmd.append("--par")
         #cmd.append("{0}".format(args.par))
     runcmd(cmd)


### PR DESCRIPTION
Since sci_plots.py uses the event file header keyword “OBS_ID”, this
keyword is now replaced (in nicer_ql) by the name of the pipeline
directory. This is more informative than the wrong ObsID number. The
user can set the pipeline output directory name with —outdir.