### PR TITLE
 Remove unused import (incompatible with python3)

### DIFF
--- a/scripts/niphaseogram.py
+++ b/scripts/niphaseogram.py
@@ -8,7 +8,6 @@
 # Then, fits TOAs and outputs them in tempo2 format.
 from __future__ import division, print_function
 import sys, math, os
-from commands import getstatusoutput
 from optparse import OptionParser
 import numpy as np
 import pylab


### PR DESCRIPTION
The commands package has been deprecacted in python3.
https://docs.python.org/2/library/commands.html

It is unused in this script, and I assume a remnant from early development