### PR TITLE
Faster Background Plots

### DIFF
--- a/nicer/NicerFileSet.py
+++ b/nicer/NicerFileSet.py
@@ -105,12 +105,13 @@ class NicerFileSet:
             self.etable = apply_gti(self.etable,g)
             self.gtitable = g
 
-        #Compiling HK Data
-        if args.extraphkshootrate:
-            self.quickhkshootrate()
-        else:
-            self.hkshootrate()
+        # Compiling HK Data
+        # if args.extraphkshootrate:
+        #     self.quickhkshootrate()
+        # else:
+        #     self.hkshootrate()
         # self.geteventshoots()
+        # self.reset_rates = None
 
     def createetable(self):
         log.info('Reading files')
@@ -151,115 +152,115 @@ class NicerFileSet:
         if self.args.object is not None:
             self.etable.meta['OBJECT'] = self.args.object
 
-    def quickhkshootrate(self):
-        'Compute HK shoot rates from a single MPU*7 instead of trying to sum all MPUs. This avoids errors when time axes are not compatible'
-        log.info('Getting HKP quick overshoot and undershoot rates from one MPU')
-        if len(self.hkfiles) > 0:
-            log.info('Reading '+self.hkfiles[4])
-            hdulist = pyfits.open(self.hkfiles[4])
-            td = hdulist[1].data
-            self.hkmet = td['TIME']
-            log.info("HK MET Range {0} to {1} (Span = {2:.1f} seconds)".format(self.hkmet.min(),
-                self.hkmet.max(),self.hkmet.max()-self.hkmet.min()))
-            # Only read one MPU so multiply by 7 to extrapolate to full rates
-            self.hkovershoots = td['MPU_OVER_COUNT'].sum(axis=1)*7
-            self.hkundershoots = td['MPU_UNDER_COUNT'].sum(axis=1)*7
-            # Here we don't get reset rates for all MPUS
-            nresets = td['MPU_UNDER_COUNT'].sum(axis=0)
-            del hdulist
-            self.reset_rates = None
+    # def quickhkshootrate(self):
+    #     'Compute HK shoot rates from a single MPU*7 instead of trying to sum all MPUs. This avoids errors when time axes are not compatible'
+    #     log.info('Getting HKP quick overshoot and undershoot rates from one MPU')
+    #     if len(self.hkfiles) > 0:
+    #         log.info('Reading '+self.hkfiles[4])
+    #         hdulist = pyfits.open(self.hkfiles[4])
+    #         td = hdulist[1].data
+    #         self.hkmet = td['TIME']
+    #         log.info("HK MET Range {0} to {1} (Span = {2:.1f} seconds)".format(self.hkmet.min(),
+    #             self.hkmet.max(),self.hkmet.max()-self.hkmet.min()))
+    #         # Only read one MPU so multiply by 7 to extrapolate to full rates
+    #         self.hkovershoots = td['MPU_OVER_COUNT'].sum(axis=1)*7
+    #         self.hkundershoots = td['MPU_UNDER_COUNT'].sum(axis=1)*7
+    #         # Here we don't get reset rates for all MPUS
+    #         nresets = td['MPU_UNDER_COUNT'].sum(axis=0)
+    #         del hdulist
+    #         self.reset_rates = None
 
-            timecol = pyfits.Column(name='HKTIME',array=self.hkmet, format = 'D')
-            ovscol = pyfits.Column(name = 'HK_OVERSHOOT', array = self.hkovershoots, format = 'D')
-            undcol = pyfits.Column(name = 'HK_UNDERSHOOT',array = self.hkundershoots, format = 'D')
+    #         timecol = pyfits.Column(name='HKTIME',array=self.hkmet, format = 'D')
+    #         ovscol = pyfits.Column(name = 'HK_OVERSHOOT', array = self.hkovershoots, format = 'D')
+    #         undcol = pyfits.Column(name = 'HK_UNDERSHOOT',array = self.hkundershoots, format = 'D')
 
-            self.hkshoottable = Table([self.hkmet, self.hkovershoots, self.hkundershoots],names = ('HKMET', 'HK_OVERSHOOTS', 'HK_UNDERSHOOTS'))
-        else:
-            hkmet = None
-            hkovershoots = None
-            hkundershoots = None
-            nresets = calc_nresets(self.etable, IDS)
-            reset_rates = nresets/self.etable.meta['EXPOSURE']
+    #         self.hkshoottable = Table([self.hkmet, self.hkovershoots, self.hkundershoots],names = ('HKMET', 'HK_OVERSHOOTS', 'HK_UNDERSHOOTS'))
+    #     else:
+    #         hkmet = None
+    #         hkovershoots = None
+    #         hkundershoots = None
+    #         nresets = calc_nresets(self.etable, IDS)
+    #         reset_rates = nresets/self.etable.meta['EXPOSURE']
 
-    def hkshootrate(self):
-        # getting the overshoot and undershoot rate from HK files.  Times are hkmet
-        log.info('Getting HKP overshoot and undershoot rates')
-        if len(self.hkfiles) > 0:
-            log.info('Reading '+self.hkfiles[0])
-            hdulist = pyfits.open(self.hkfiles[0])
-            td = hdulist[1].data
-            self.hkmet = td['TIME']
-            log.info("HK MET Range {0} to {1} (Span = {2:.1f} seconds)".format(self.hkmet.min(),
-                self.hkmet.max(),self.hkmet.max()-self.hkmet.min()))
-            self.hkovershoots = td['MPU_OVER_COUNT'].sum(axis=1)
-            self.hkundershoots = td['MPU_UNDER_COUNT'].sum(axis=1)
-            nresets = td['MPU_UNDER_COUNT'].sum(axis=0)
-            for fn in self.hkfiles[1:]:
-                log.info('Reading '+fn)
-                hdulist = pyfits.open(fn)
-                mytd = hdulist[1].data
-                mymet = mytd['TIME']
-                myhkovershoots= mytd['MPU_OVER_COUNT'].sum(axis=1)
-                myhkundershoots = mytd['MPU_UNDER_COUNT'].sum(axis=1)
-                # If time axis is bad, skip this MPU.
-                # Should fix this!
+    # def hkshootrate(self):
+    #     # getting the overshoot and undershoot rate from HK files.  Times are hkmet
+    #     log.info('Getting HKP overshoot and undershoot rates')
+    #     if len(self.hkfiles) > 0:
+    #         log.info('Reading '+self.hkfiles[0])
+    #         hdulist = pyfits.open(self.hkfiles[0])
+    #         td = hdulist[1].data
+    #         self.hkmet = td['TIME']
+    #         log.info("HK MET Range {0} to {1} (Span = {2:.1f} seconds)".format(self.hkmet.min(),
+    #             self.hkmet.max(),self.hkmet.max()-self.hkmet.min()))
+    #         self.hkovershoots = td['MPU_OVER_COUNT'].sum(axis=1)
+    #         self.hkundershoots = td['MPU_UNDER_COUNT'].sum(axis=1)
+    #         nresets = td['MPU_UNDER_COUNT'].sum(axis=0)
+    #         for fn in self.hkfiles[1:]:
+    #             log.info('Reading '+fn)
+    #             hdulist = pyfits.open(fn)
+    #             mytd = hdulist[1].data
+    #             mymet = mytd['TIME']
+    #             myhkovershoots= mytd['MPU_OVER_COUNT'].sum(axis=1)
+    #             myhkundershoots = mytd['MPU_UNDER_COUNT'].sum(axis=1)
+    #             # If time axis is bad, skip this MPU.
+    #             # Should fix this!
 
-                if not np.array_equal(mymet, self.hkmet):
-                    log.error('Time axes are not compatible')
-                else:
-                    self.hkovershoots += myhkovershoots
-                    self.hkundershoots += myhkundershoots
+    #             if not np.array_equal(mymet, self.hkmet):
+    #                 log.error('Time axes are not compatible')
+    #             else:
+    #                 self.hkovershoots += myhkovershoots
+    #                 self.hkundershoots += myhkundershoots
 
-                myreset = mytd['MPU_UNDER_COUNT'].sum(axis=0)
-                nresets = np.append(nresets,myreset)
-            del hdulist
-            self.reset_rates = nresets / np.float(self.etable.meta['EXPOSURE'])
+    #             myreset = mytd['MPU_UNDER_COUNT'].sum(axis=0)
+    #             nresets = np.append(nresets,myreset)
+    #         del hdulist
+    #         self.reset_rates = nresets / np.float(self.etable.meta['EXPOSURE'])
 
-            timecol = pyfits.Column(name='HKTIME',array=self.hkmet, format = 'D')
-            ovscol = pyfits.Column(name = 'HK_OVERSHOOT', array = self.hkovershoots, format = 'D')
-            undcol = pyfits.Column(name = 'HK_UNDERSHOOT',array = self.hkundershoots, format = 'D')
+    #         timecol = pyfits.Column(name='HKTIME',array=self.hkmet, format = 'D')
+    #         ovscol = pyfits.Column(name = 'HK_OVERSHOOT', array = self.hkovershoots, format = 'D')
+    #         undcol = pyfits.Column(name = 'HK_UNDERSHOOT',array = self.hkundershoots, format = 'D')
 
-            self.hkshoottable = Table([self.hkmet, self.hkovershoots, self.hkundershoots],names = ('HKMET', 'HK_OVERSHOOTS', 'HK_UNDERSHOOTS'))
+    #         self.hkshoottable = Table([self.hkmet, self.hkovershoots, self.hkundershoots],names = ('HKMET', 'HK_OVERSHOOTS', 'HK_UNDERSHOOTS'))
 
-        else:
-            hkmet = None
-            hkovershoots = None
-            hkundershoots = None
-            nresets = calc_nresets(self.etable, IDS)
-            reset_rates = nresets/self.etable.meta['EXPOSURE']
+    #     else:
+    #         hkmet = None
+    #         hkovershoots = None
+    #         hkundershoots = None
+    #         nresets = calc_nresets(self.etable, IDS)
+    #         reset_rates = nresets/self.etable.meta['EXPOSURE']
 
-    def geteventshoots(self):
-        log.info('Getting event shoot rates')
-        # Define bins for hkmet histogram
-        hkmetbins = np.append(self.hkmet,(self.hkmet[-1]+self.hkmet[1]-self.hkmet[0]))
+    # def geteventshoots(self):
+    #     log.info('Getting event shoot rates')
+    #     # Define bins for hkmet histogram
+    #     hkmetbins = np.append(self.hkmet,(self.hkmet[-1]+self.hkmet[1]-self.hkmet[0]))
 
-        if self.args.eventshootrate or self.args.writebkf:
-            #Both under and overshoot
-            if len(self.uffiles) == 0:
-                filelist = self.evfiles
-            else:
-                filelist = self.uffiles
-            etable = get_eventbothshoots_ftools(filelist,workdir=None)
-            self.eventbothshoots, edges = np.histogram(etable['TIME'],hkmetbins)
-            #Just overshoot
-            etable = get_eventovershoots_ftools(filelist,workdir=None)
-            self.eventovershoots, edges = np.histogram(etable['TIME'],hkmetbins)
+    #     if self.args.eventshootrate or self.args.writebkf:
+    #         #Both under and overshoot
+    #         if len(self.uffiles) == 0:
+    #             filelist = self.evfiles
+    #         else:
+    #             filelist = self.uffiles
+    #         etable = get_eventbothshoots_ftools(filelist,workdir=None)
+    #         self.eventbothshoots, edges = np.histogram(etable['TIME'],hkmetbins)
+    #         #Just overshoot
+    #         etable = get_eventovershoots_ftools(filelist,workdir=None)
+    #         self.eventovershoots, edges = np.histogram(etable['TIME'],hkmetbins)
 
-            self.eventshoottable = Table([self.hkmet, self.eventovershoots, self.eventbothshoots],names = ('HKMET', 'EVENT_OVERSHOOTS', 'EVENT_BOTHSHOOTS'))
-            del etable
-        else:
-            self.eventbothshoots = None
-            self.eventovershoots = None
+    #         self.eventshoottable = Table([self.hkmet, self.eventovershoots, self.eventbothshoots],names = ('HKMET', 'EVENT_OVERSHOOTS', 'EVENT_BOTHSHOOTS'))
+    #         del etable
+    #     else:
+    #         self.eventbothshoots = None
+    #         self.eventovershoots = None
 
-        # Don't compute this unless specifically requested, because it can be slow
-        if self.args.eventshootrate:
-            etable = get_eventundershoots_ftools(filelist,workdir=None)
-            self.eventundershoots, edges = np.histogram(etable['TIME'],hkmetbins)
-            self.eventshoottable = Table([self.hkmet, self.eventovershoots, self.eventundershoots, self.eventbothshoots],names = ('HKMET', 'EVENT_OVERSHOOTS', 'EVENT_UNDERSHOOTS', 'EVENT_BOTHSHOOTS'))
-            del etable
+    #     # Don't compute this unless specifically requested, because it can be slow
+    #     if self.args.eventshootrate:
+    #         etable = get_eventundershoots_ftools(filelist,workdir=None)
+    #         self.eventundershoots, edges = np.histogram(etable['TIME'],hkmetbins)
+    #         self.eventshoottable = Table([self.hkmet, self.eventovershoots, self.eventundershoots, self.eventbothshoots],names = ('HKMET', 'EVENT_OVERSHOOTS', 'EVENT_UNDERSHOOTS', 'EVENT_BOTHSHOOTS'))
+    #         del etable
 
-        else:
-            self.eventundershoots = None
+    #     else:
+    #         self.eventundershoots = None
 
     def writebkffile(self):
         # Write useful rates  to file for filtering

--- a/nicer/NicerFileSet.py
+++ b/nicer/NicerFileSet.py
@@ -110,7 +110,7 @@ class NicerFileSet:
             self.quickhkshootrate()
         else:
             self.hkshootrate()
-        self.geteventshoots()
+        # self.geteventshoots()
 
     def createetable(self):
         log.info('Reading files')

--- a/nicer/bkg_plots.py
+++ b/nicer/bkg_plots.py
@@ -7,18 +7,19 @@ from astropy import log
 from nicer.plotutils import *
 from nicer.fitsutils import *
 
-def bkg_plots(etable, data, gtitable, args, mktable, shoottable):
+#def bkg_plots(etable, data, gtitable, args, mktable, shoottable):
+def bkg_plots(etable, gtitable, args, mktable):
 
-    if args.eventshootrate:
-        overshootrate = shoottable['EVENT_OVERSHOOTS']
-        undershootrate = shoottable['EVENT_UNDERSHOOTS']
-        bothrate = shoottable['EVENT_BOTHSHOOTS']
-        hkmet = shoottable['HKMET']
-    else:
-        overshootrate = shoottable['HK_OVERSHOOTS']
-        undershootrate = shoottable['HK_UNDERSHOOTS']
-        bothrate = None
-        hkmet = shoottable['HKMET']
+    # if args.eventshootrate:
+    #     overshootrate = shoottable['EVENT_OVERSHOOTS']
+    #     undershootrate = shoottable['EVENT_UNDERSHOOTS']
+    #     bothrate = shoottable['EVENT_BOTHSHOOTS']
+    #     hkmet = shoottable['HKMET']
+    # else:
+    #     overshootrate = shoottable['HK_OVERSHOOTS']
+    #     undershootrate = shoottable['HK_UNDERSHOOTS']
+    #     bothrate = None
+    #     hkmet = shoottable['HKMET']
 
     figure = plt.figure(figsize = (8.5, 11), facecolor = 'white')
     bkg_grid = gridspec.GridSpec(29,4)
@@ -27,25 +28,29 @@ def bkg_plots(etable, data, gtitable, args, mktable, shoottable):
     log.info('Building Rejected Event Light curve')
     plt.subplot(bkg_grid[1:5,:4])
 
-    hkmetbins = np.append(hkmet,(hkmet[-1]+hkmet[1]-hkmet[0]))
+    # hkmetbins = np.append(hkmet,(hkmet[-1]+hkmet[1]-hkmet[0]))
 
     # Extract bad ratio events and bin onto hkmet bins
-    if len(data.ufafiles) == 0:
-        badtable = get_badratioevents_ftools(data.evfiles,workdir=None)
-    else:
-        badtable = get_badratioevents_ftools(data.ufafiles,workdir=None)
-    badlightcurve = np.histogram(badtable['TIME'], hkmetbins)[0]
-    badlightcurve = np.array(badlightcurve,dtype=np.float)
+    # if len(data.ufafiles) == 0:
+    #     badtable = get_badratioevents_ftools(data.evfiles,workdir=None)
+    # else:
+    #     badtable = get_badratioevents_ftools(data.ufafiles,workdir=None)
+    # badlightcurve = np.histogram(badtable['TIME'], hkmetbins)[0]
+    # badlightcurve = np.array(badlightcurve,dtype=np.float)
+
+    badlightcurve = 52*mktable['FPM_RATIO_REJ_COUNT']
 
     colornames, cmap, norm = gti_colormap()
 
-    times, lc, cc = convert_to_elapsed_goodtime(hkmet, badlightcurve, gtitable)
+    # times, lc, cc = convert_to_elapsed_goodtime(hkmet, badlightcurve, gtitable)
+    times, lc, cc = convert_to_elapsed_goodtime(mktable['TIME'], badlightcurve, gtitable)
     plot.scatter(times, lc, c=np.fmod(cc,len(colornames)), cmap=cmap, norm=norm, marker='.')
 
     # Really should convolve in GTI segments!
     kernel = np.ones(32)/32.0
     badsmooth = np.convolve(badlightcurve,kernel,mode='same')
-    times, lc, cc = convert_to_elapsed_goodtime(hkmet, badsmooth, gtitable)
+    # times, lc, cc = convert_to_elapsed_goodtime(hkmet, badsmooth, gtitable)
+    times, lc, cc = convert_to_elapsed_goodtime(mktable['TIME'], badsmooth, gtitable)
     plot.plot(times, lc)
 
     plot.yscale('symlog',linthreshy=5.0)
@@ -57,17 +62,20 @@ def bkg_plots(etable, data, gtitable, args, mktable, shoottable):
     #Overshoot rate plot -- use --lclog to make it a log y axis
     log.info('Building overshoot plot')
     plt.subplot(bkg_grid[5:9,:4])
-    if overshootrate is not None:
-        plot_overshoot(etable, overshootrate, gtitable, args, hkmet, bothrate)
-        plot_SAA(mktable, gtitable, overshootrate)
+    # if overshootrate is not None:
+    # plot_overshoot(etable, overshootrate, gtitable, args, hkmet, bothrate, mktable)
+    plot_overshoot(mktable, gtitable, args)
+    # plot_SAA(mktable, gtitable, overshootrate)
+    plot_SAA(mktable, gtitable)
 
     #Plot of undershoot rate
     log.info('Building undershoot plot')
     plt.subplot(bkg_grid[9:13,:4])
-    if undershootrate is not None:
-        plot_undershoot(etable, undershootrate, gtitable, args, hkmet, mktable)
-
-    #Plot of Sun / Moon
+    # if undershootrate is not None:
+    #    plot_undershoot(etable, undershootrate, gtitable, args, hkmet, mktable)
+    plot_undershoot(mktable, gtitable, args)
+    
+    #Plot of Sun / Moon -- mktable
     log.info('Building Sun / Moon / Earth angle Plot')
     plt.subplot(bkg_grid[13:17,:4])
     plot_angles(mktable, gtitable)

--- a/nicer/eng_plots.py
+++ b/nicer/eng_plots.py
@@ -7,7 +7,8 @@ import argparse
 from nicer.plotutils import *
 from nicer.values import *
 
-def eng_plots(etable, args, reset_rates, filttable, gtitable):
+#def eng_plots(etable, args, reset_rates, filttable, gtitable):
+def eng_plots(etable, args, filttable, gtitable):
     #GRID SET UP
     figure1 = plot.figure(figsize = (11, 8.5), facecolor = 'white')
     sci_grid = gridspec.GridSpec(5,6)
@@ -28,6 +29,7 @@ def eng_plots(etable, args, reset_rates, filttable, gtitable):
 
     #RESET RATE PER DETECTOR
     log.info('Computing reset rates')
+    reset_rates = None 
     plot.subplot(sci_grid[:2, 2:4])
     if reset_rates is not None:
         plot_resetrate(IDS, reset_rates)
@@ -68,7 +70,7 @@ def eng_plots(etable, args, reset_rates, filttable, gtitable):
 
 
 
-def plot_all_spectra(etable, args, reset_rates, filttable, gtitable):
+def plot_all_spectra(etable, args, filttable, gtitable):
     #GRID SET UP
     fig_all_spec = plot.figure(figsize = (11, 8.5), facecolor = 'white')    
     ncols = 8
@@ -97,7 +99,7 @@ def plot_all_spectra(etable, args, reset_rates, filttable, gtitable):
     return fig_all_spec
 
 
-def plot_all_lc(etable, args, reset_rates, filttable, gtitable):
+def plot_all_lc(etable, args, filttable, gtitable):
     #GRID SET UP
     fig_all_lc = plot.figure(figsize = (11, 8.5), facecolor = 'white')    
     ncols = 8

--- a/nicer/fitsutils.py
+++ b/nicer/fitsutils.py
@@ -162,7 +162,8 @@ def get_badratioevents_ftools(evfiles,workdir=None):
     # Build input file for ftmerge
     evlistname=path.join(tmpdir,'evfiles.txt')
     fout = open(evlistname,'w')
-    evfilt_expr = '(EVENT_FLAGS==bx11000).and.((float)PI/(float)PI_FAST > (1.0 + 25.0/(float)PI + 4.0E-11*(float)PI**3))'
+    #evfilt_expr = '(EVENT_FLAGS==bx11000).and.((float)PI/(float)PI_FAST > (1.0 + 25.0/(float)PI + 4.0E-11*(float)PI**3))'
+    evfilt_expr = '(EVENT_FLAGS==bx11000).and.((float)PI/(float)PI_FAST > (1.1 + 120.0/(float)PI + 0.0E-11*(float)PI**3))'
     for en in evfiles:
         print('{0}[{1}]'.format(en,evfilt_expr),file=fout)
     fout.close()

--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -227,19 +227,19 @@ if gtitable is not None:
         cumtime += mylcduration
     gtitable['CUMTIME'] = np.array(cumtimes)
 
-#Getting over/undershoot rate from event data.
-if args.eventshootrate:
-    eventovershoots = data.eventovershoots
-    eventundershoots = data.eventundershoots
-    eventbothshoots = data.eventbothshoots
-else:
-    eventbothshoots = None
-    eventundershoots = None
-    eventovershoots = None
+# Getting over/undershoot rate from event data.
+# if args.eventshootrate:
+#     eventovershoots = data.eventovershoots
+#     eventundershoots = data.eventundershoots
+#     eventbothshoots = data.eventbothshoots
+# else:
+#     eventbothshoots = None
+#     eventundershoots = None
+#     eventovershoots = None
 
 if args.obsdir is not None:
-    hkovershoots = data.hkovershoots
-    hkundershoots = data.hkundershoots
+#     hkovershoots = data.hkovershoots
+#     hkundershoots = data.hkundershoots
     reset_rates = data.reset_rates
 
 # Write overshoot and undershoot rates to file for filtering

--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -79,7 +79,7 @@ if np.logical_or(args.obsdir is not None, args.infiles is not None):
         gtitable = data.gtitable
         #Some Definitions
         mktable = data.mktable
-        hkmet = data.hkmet
+        #hkmet = data.hkmet
         basename = data.basename
     else:
         #Creating the data table for each separate file
@@ -149,12 +149,12 @@ if np.logical_or(args.obsdir is not None, args.infiles is not None):
 
         if args.mkf is not None:
             mktable = Table.read(args.mkf,hdu=1)
-            if 'TIMEZERO' in self.mktable.meta:
+            if 'TIMEZERO' in mktable.meta:
                 log.info('Applying TIMEZERO of {0} to mktable in nicerql'.format(mktable.meta['TIMEZERO']))
                 mktable['TIME'] += mktable.meta['TIMEZERO']
                 mktable.meta['TIMEZERO'] = 0.0
         
-        reset_rates = None
+        # reset_rates = None
 else:
     log.warning('You have not specified any files, please input the path to the files you want to see. Exiting.')
     sys.exit()
@@ -237,10 +237,10 @@ if gtitable is not None:
 #     eventundershoots = None
 #     eventovershoots = None
 
-if args.obsdir is not None:
+#if args.obsdir is not None:
 #     hkovershoots = data.hkovershoots
 #     hkundershoots = data.hkundershoots
-    reset_rates = data.reset_rates
+#     reset_rates = data.reset_rates
 
 # Write overshoot and undershoot rates to file for filtering
 if args.writebkf:
@@ -323,23 +323,24 @@ log.info('Exposure : {0:.2f}'.format(etable.meta['EXPOSURE']))
 #------------------------------------------------------PLOTTING HAPPENS BELOW HERE ------------------------------------------------------
 # Background plots are diagnostics for background rates and filtering
 if args.bkg:
-    if hkmet is None:
-        log.error("Can't make background plots without MPU HKP files")
-    else:
+    #if hkmet is None:
+    #    log.error("Can't make background plots without MPU HKP files")
+    #else:
     #     if eventovershoots is not None:
     #         figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.eventshoottable)
     #     else:
     #         figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.hkshoottable)
 
-        figure4 = bkg_plots(etable, gtitable, args, mktable)
-        figure4.set_size_inches(16,12)
-        if args.save:
-            log.info('Writing bkg plot {0}'.format(basename))
-            figure4.savefig('{0}_bkg.png'.format(basename), dpi = 100)
+    figure4 = bkg_plots(etable, gtitable, args, mktable)
+    figure4.set_size_inches(16,12)
+    if args.save:
+        log.info('Writing bkg plot {0}'.format(basename))
+        figure4.savefig('{0}_bkg.png'.format(basename), dpi = 100)
 
 # Engineering plots are reset rates, count rates by detector, and deadtime
 if args.eng:
-    figure1 = eng_plots(etable, args, reset_rates, filttable, gtitable)
+    # figure1 = eng_plots(etable, args, reset_rates, filttable, gtitable)
+    figure1 = eng_plots(etable, args, filttable, gtitable)
     figure1.set_size_inches(16,12)
     if args.save:
         log.info('Writing eng plot {0}'.format(basename))
@@ -390,7 +391,7 @@ if args.interactive:
 # Plot all DetID spectra if --allspec
 if args.allspec:
     log.info("")
-    figure5 = plot_all_spectra(etable, args, reset_rates, filttable, gtitable)
+    figure5 = plot_all_spectra(etable, args, filttable, gtitable)
     figure5.set_size_inches(16,12)
     if args.save:
         log.info('Writing all spectral plot {0}'.format(basename))
@@ -399,7 +400,7 @@ if args.allspec:
 # Plot all DET_ID lightcurve if --alllc
 if args.alllc:
     log.info("")
-    figure6 = plot_all_lc(etable, args, reset_rates, filttable, gtitable)
+    figure6 = plot_all_lc(etable, args, filttable, gtitable)
     figure6.set_size_inches(16,12)
     if args.save:
         log.info('Writing all lightcurve plot {0}'.format(basename))

--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -52,9 +52,10 @@ parser.add_argument("--lclog", help = "make light curve log axis", action = "sto
 parser.add_argument("--foldfreq", help="Make pulse profile by folding at a fixed freq (Hz)",default=0.0,type=float)
 parser.add_argument("--nyquist", help="Nyquist freq for power spectrum (Hz)",default=100.0,type=float)
 parser.add_argument("--map", help= "Creates a map with overshoots and undershoots", action = 'store_true')
-parser.add_argument("--orb", help="Path to orbit FITS filed", default = None)
+parser.add_argument("--orb", help="Path to orbit FITS files", default = None)
 parser.add_argument("--par", help="Path to par file", default = None)
 parser.add_argument("--sps", help="Path to SPS HK file (_apid0260.hk)",default=None)
+parser.add_argument("--mkf", help="Path to MKF file",default=None)
 parser.add_argument("--powspec",help = "Display power spectrum (replaces ratio plot)", action = 'store_true')
 parser.add_argument("--pslog", help = "make power spectrum log axis", action = "store_true")
 parser.add_argument("--writeps", help = "write out power spectrum", action = "store_true")
@@ -146,6 +147,13 @@ if np.logical_or(args.obsdir is not None, args.infiles is not None):
         else:
             basename = args.basename
 
+        if args.mkf is not None:
+            mktable = Table.read(args.mkf,hdu=1)
+            if 'TIMEZERO' in self.mktable.meta:
+                log.info('Applying TIMEZERO of {0} to mktable in nicerql'.format(mktable.meta['TIMEZERO']))
+                mktable['TIME'] += mktable.meta['TIMEZERO']
+                mktable.meta['TIMEZERO'] = 0.0
+        
         reset_rates = None
 else:
     log.warning('You have not specified any files, please input the path to the files you want to see. Exiting.')
@@ -359,13 +367,14 @@ if args.sci:
 # Map plot is overshoot and undershoot rates on maps
 if args.map:
     log.info("I'M THE MAP I'M THE MAP I'M THE MAAAAP")
-    if eventovershoots is not None:
-        figure3 = cartography(hkmet, eventovershoots, args, eventundershoots,
-            filttable, mktable, gtitable)
-    else:
-        figure3 = cartography(hkmet, hkovershoots, args, hkundershoots,
-            filttable, mktable, gtitable)
-
+    # if eventovershoots is not None:
+    #     figure3 = cartography(hkmet, eventovershoots, args, eventundershoots,
+    #         filttable, mktable, gtitable)
+    # else:
+    #     figure3 = cartography(hkmet, hkovershoots, args, hkundershoots,
+    #         filttable, mktable, gtitable)
+    
+    figure3 = cartography(filttable, mktable, gtitable, args)
     if args.save:
         log.info('Writing MAP {0}'.format(basename))
         figure3.savefig('{0}_map.png'.format(basename), dpi = 100)

--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -318,10 +318,12 @@ if args.bkg:
     if hkmet is None:
         log.error("Can't make background plots without MPU HKP files")
     else:
-        if eventovershoots is not None:
-            figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.eventshoottable)
-        else:
-            figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.hkshoottable)
+    #     if eventovershoots is not None:
+    #         figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.eventshoottable)
+    #     else:
+    #         figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.hkshoottable)
+
+        figure4 = bkg_plots(etable, gtitable, args, mktable)
         figure4.set_size_inches(16,12)
         if args.save:
             log.info('Writing bkg plot {0}'.format(basename))

--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -152,14 +152,14 @@ for obsdir in all_obsids:
         ufaevents = ufaevents + nevents
 
     if ufaevents < 10000000:
-        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0","--allspec","--alllc",
+        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0", ##  "--allspec","--alllc",
                "--lclog", "--useftools", "--extraphkshootrate",
                "--eventshootrate",
                "--emin", "{0}".format(args.emin), "--emax", "{0}".format(args.emax),
                "--sci", "--eng", "--bkg", "--map", "--obsdir", obsdir,
                "--basename", path.join(pipedir,basename)+'_prefilt']
     else:
-        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0","--allspec","--alllc",
+        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0", ## "--allspec","--alllc",
                "--lclog", "--useftools", "--extraphkshootrate",
                "--emin", "{0}".format(args.emin), "--emax", "{0}".format(args.emax),
                "--sci", "--eng", "--bkg", "--map", "--obsdir", obsdir,

--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -334,16 +334,16 @@ for obsdir in all_obsids:
     #os.remove(intermediatename)
 
     # Make cleanfilt.mkf file from ObsID .mkf file and merged_GTI
-    # --- NOT IMPLEMENTED --- #
-    # cleanfilt_mkf = path.join(pipedir,"cleanfilt.mkf")
-    # cmd = ["fltime", "infile='{}[1]'".format(mkfile), "gtifile='{}".format(gtiname_merged),"outfile='{}'".format(cleanfilt_mkf)]
-    # runcmd(cmd)
+    cleanfilt_mkf = path.join(pipedir,"cleanfilt.mkf")
+    log.info('Applying the GTI filtering to the *mkf file')
+    cmd = ["fltime", "infile={}[1]".format(mkfile), "gtifile={}".format(gtiname_merged),"outfile={}".format(cleanfilt_mkf),"clobber=yes"]
+    runcmd(cmd)
 
     # Make final clean plot
     cmd = ["nicerql.py", "--save",
            "--orb", path.join(pipedir,path.basename(orbfile)),
            "--sci", "--eng", filteredname, "--lcbinsize", "4.0","--allspec","--alllc",
-           # "--mkf", cleanfilt_mkf,  # --- NOT IMPLEMENTED --- #
+           "--mkf", cleanfilt_mkf, "--bkg",
            "--basename", path.join(pipedir,basename)+"_cleanfilt"]
     if args.par is not None:
         cmd.append("--par")


### PR DESCRIPTION
Updated bkg_plots to get Over/Under/Double from the mktable instead of from the event files. 
See #34 

Note 1: As it stands, running psrpipe will not be faster since the Over/Under shoots are still obtained from the event table. Some clean up is required.

Note 2: I am multiplying the `FPM_XXX_COUNT (Per-FPM XXX reset count from events)` obtained from the .mkf file by 52 FPM in order to get the total.