### PR TITLE
Implementation of MaxOvershoot filtering from binned overshoot lightcurve

### DIFF
--- a/nicer/bkg_plots.py
+++ b/nicer/bkg_plots.py
@@ -8,7 +8,7 @@ from nicer.plotutils import *
 from nicer.fitsutils import *
 
 #def bkg_plots(etable, data, gtitable, args, mktable, shoottable):
-def bkg_plots(etable, gtitable, args, mktable):
+def bkg_plots(etable, gtitable, args, mktable, ovbintable):
 
     # if args.eventshootrate:
     #     overshootrate = shoottable['EVENT_OVERSHOOTS']
@@ -64,7 +64,7 @@ def bkg_plots(etable, gtitable, args, mktable):
     plt.subplot(bkg_grid[5:9,:4])
     # if overshootrate is not None:
     # plot_overshoot(etable, overshootrate, gtitable, args, hkmet, bothrate, mktable)
-    plot_overshoot(mktable, gtitable, args)
+    plot_overshoot(mktable, ovbintable, gtitable, args)
     # plot_SAA(mktable, gtitable, overshootrate)
     plot_SAA(mktable, gtitable)
 

--- a/nicer/eng_plots.py
+++ b/nicer/eng_plots.py
@@ -117,18 +117,18 @@ def plot_all_lc(etable, args, filttable, gtitable):
         idx = np.where(filttable['DET_ID']==detid)[0]
         plot.subplot(lc_grid[row, col])
         if col==0:
-            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=5*args.lcbinsize,plot_pos='left')
+            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=args.lcbinsize,plot_pos='left')
 
         if row == ((nbDET // ncols)-1):
-            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=5*args.lcbinsize,plot_pos='bottom')
+            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=args.lcbinsize,plot_pos='bottom')
             plot.xlabel('Time (s)')
             
         if (col==0) and (row == ((nbDET // ncols)-1) ):
-            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=5*args.lcbinsize,plot_pos='corner')
+            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=args.lcbinsize,plot_pos='corner')
             plot.xlabel('Time (s)')
             
         if (col!=0) and (row != ((nbDET // ncols)-1) ):
-            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=5*args.lcbinsize,plot_pos='center')
+            meanrate, a = plot_light_curve(filttable[idx], args.lclog, gtitable, binsize=args.lcbinsize,plot_pos='center')
 
         plot.title('DET_ID {0}'.format(detid))
 

--- a/nicer/plotutils.py
+++ b/nicer/plotutils.py
@@ -536,7 +536,7 @@ def convert_to_elapsed_goodtime(mets, vals, gtitable):
     return etimes, goodvals, cc
 
 #def plot_overshoot(etable, overshootrate, gtitable, args, hkmet, bothrate, mktable):
-def plot_overshoot(mktable, gtitable, args):
+def plot_overshoot(mktable, ovbintable, gtitable, args):
 
     #etime, overshoot, cc = convert_to_elapsed_goodtime(hkmet, overshootrate, gtitable)
     etime, overshoot, cc = convert_to_elapsed_goodtime(mktable['TIME'], 52*mktable['FPM_OVERONLY_COUNT'], gtitable)
@@ -552,16 +552,20 @@ def plot_overshoot(mktable, gtitable, args):
     plot.scatter(ovtime, overshoot, c=np.fmod(cc,len(colornames)), cmap=cmap,
         norm=norm, marker='+',label='Overshoot rate')
     
-    #if bothrate is not None:
-        #etime, both, cc = convert_to_elapsed_goodtime(hkmet, bothrate, gtitable)
-    etime, both, cc = convert_to_elapsed_goodtime(mktable['TIME'], 52*mktable['FPM_DOUBLE_COUNT'], gtitable)
-    plot.scatter(etime, both, color='c', marker='.', label='Both Under and Over Flags')
-    plot.legend(loc = 2)
+    if ovbintable is not None:
+        etime, binnedOV, cc = convert_to_elapsed_goodtime(ovbintable['TIME'], 52*ovbintable['FPM_OVERONLY_COUNT'], gtitable)
+        plot.plot(etime, binnedOV, linewidth=2.0)
+    else:
+        # if bothrate is not None:
+        #      etime, both, cc = convert_to_elapsed_goodtime(hkmet, bothrate, gtitable)
+        etime, both, cc = convert_to_elapsed_goodtime(mktable['TIME'], 52*mktable['FPM_DOUBLE_COUNT'], gtitable)
+        plot.scatter(etime, both, color='c', marker='.', label='Both Under and Over Flags')
+        plot.yscale('symlog',linthreshy=10.0)
 
+    plot.legend(loc = 2)
     plot.ylabel('Overshoot rate')
     plot.grid(True)
 
-    plot.yscale('symlog',linthreshy=10.0)
     return
 
 #def plot_SAA(mktable, gtitable, overshootrate):

--- a/scripts/nicerql.py
+++ b/scripts/nicerql.py
@@ -81,6 +81,7 @@ if np.logical_or(args.obsdir is not None, args.infiles is not None):
         mktable = data.mktable
         #hkmet = data.hkmet
         basename = data.basename
+        ovbintable = data.ovbintable
     else:
         #Creating the data table for each separate file
         if args.useftools:
@@ -156,6 +157,17 @@ if np.logical_or(args.obsdir is not None, args.infiles is not None):
         else:
             mktable = None
         # reset_rates = None
+
+        if args.bkg:
+            ovbinfile = '{0}_prefilt_ovbin.mkf'.format(basename.split('_cleanfilt')[0])
+            if path.isfile(ovbinfile):
+                log.info("Reading overshoots file present...Getting from {}".format(ovbinfile))
+                ovbintable = Table.read(ovbinfile,hdu=1)
+            else:
+                ovbintable = None
+        else:
+            ovbintable = None
+            
 else:
     log.warning('You have not specified any files, please input the path to the files you want to see. Exiting.')
     sys.exit()
@@ -332,7 +344,7 @@ if args.bkg:
     #     else:
     #         figure4 = bkg_plots(etable, data, gtitable, args, mktable, data.hkshoottable)
 
-    figure4 = bkg_plots(etable, gtitable, args, mktable)
+    figure4 = bkg_plots(etable, gtitable, args, mktable, ovbintable)
     figure4.set_size_inches(16,12)
     if args.save:
         log.info('Writing bkg plot {0}'.format(basename))

--- a/scripts/nioptcuts.py
+++ b/scripts/nioptcuts.py
@@ -10,6 +10,14 @@ from astropy.table import Table, vstack
 import astropy.units as u
 from pint.eventstats import hm,z2m
 
+
+# Python 2 (xrange) and Python 3 (range) compatibility
+try:
+    xrange
+except NameError:
+    xrange = range
+
+
 def cached_hm(mask):
     nph = mask.sum()
     if nph == 0:

--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -153,14 +153,14 @@ for obsdir in all_obsids:
         ufaevents = ufaevents + nevents
 
     if ufaevents < 10000000:
-        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0", ##  "--allspec","--alllc",
+        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "{}".format(args.lcbinsize), ##  "--allspec","--alllc",
                "--lclog", "--useftools", "--extraphkshootrate",
                "--eventshootrate",
                "--emin", "{0}".format(args.emin), "--emax", "{0}".format(args.emax),
                "--sci", "--eng", "--bkg", "--map", "--obsdir", obsdir,
                "--basename", path.join(pipedir,basename)+'_prefilt']
     else:
-        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "4.0", ## "--allspec","--alllc",
+        cmd = ["nicerql.py", "--save", "--filtall", "--lcbinsize", "{}".format(args.lcbinsize), ## "--allspec","--alllc",
                "--lclog", "--useftools", "--extraphkshootrate",
                "--emin", "{0}".format(args.emin), "--emax", "{0}".format(args.emax),
                "--sci", "--eng", "--bkg", "--map", "--obsdir", obsdir,
@@ -367,7 +367,7 @@ for obsdir in all_obsids:
             log.info('Found hot detectors {0}!!'.format(bad_dets))
         # Make intermediate eng plot to show bad detectors
         cmd = ["nicerql.py", "--save",
-               "--eng", intermediatename, "--lcbinsize", "4.0","--allspec","--alllc",
+               "--eng", intermediatename, "--lcbinsize", "{}".format(args.lcbinsize), #"--allspec","--alllc",
                "--basename", path.join(pipedir,basename)+"_intermediate"]
         runcmd(cmd)
 
@@ -400,7 +400,7 @@ for obsdir in all_obsids:
     # Make final clean plot
     cmd = ["nicerql.py", "--save",
            "--orb", path.join(pipedir,path.basename(orbfile)),
-           "--sci", "--eng", filteredname, "--lcbinsize", "4.0","--allspec","--alllc",
+           "--sci", "--eng", filteredname, "--lcbinsize", "{}".format(args.lcbinsize),"--allspec","--alllc",
            "--mkf", cleanfilt_mkf, "--bkg",
            "--basename", path.join(pipedir,basename)+"_cleanfilt"]
     if args.par is not None:


### PR DESCRIPTION
Following up on #37.  This seems to be working properly. This uses the column `FPM_OVERONLY_COUNT` from the *mkf and bins it using the --lcbinsize option (default: 4sec).
The binned overshoot lightcurve is over plotted on top of the over shoot values in the `bkg_plots`.
if the option `--maxovershoot` is added, the binned overshoot lightcurve is used to generate `gtiname3` for extra filtering with `nimaketime` in `psrpipe.py`. The whole machinery writes a few files in the pipedir, but these are not large files.

A few notes:
- In plotutils.py:  I remove the log scale in the overshoot panel of the bkg_plot
- In plotutils.py:  I removed “both rate” from the overshoot panel. It’s not really a problem to have it, but when the values of “both rate” compare to the overshoot, it’s harder to read the values of overshoots and binned_overshoots from the graph, even in log plot.

I have extensively tested this, but perhaps not exhaustively. Please report bugs that may be linked to this new feature.