### PR TITLE
Added option --keith in psrpipe.py 

### DIFF
--- a/scripts/psrpipe.py
+++ b/scripts/psrpipe.py
@@ -351,9 +351,7 @@ for obsdir in all_obsids:
         list_extra_expr.append('FPM_OVERONLY_COUNT<1')
         list_extra_expr.append('FPM_OVERONLY_COUNT<(1.52*COR_SAX**(-0.633))')
 
-    log.error(list_extra_expr)
     extra_expr = "(" + " && ".join("%s" %expr for expr in list_extra_expr) + ")"
-    log.error(extra_expr)
     
     cor_string="-"
     if args.cormin is not None:


### PR DESCRIPTION
The option `--keith` follows the standard filtering that Keith Gendreau uses to create the space-weather based background spectra.  It consists in **filtering out**

- DetID 14, 34, 54
- ST_VALID=0 (i.e. keeping only the valid star tracker flag:  ST_VALID=1)
- COR_SAX < 1.5
- FPM_OVER_ONLY > 1
- FPM_OVER_ONLY > 1.52*COR_SAX**(-0.633)
