### PR TITLE
Update sci_plots.py to fix issue #93

### DIFF
--- a/nicer/sci_plots.py
+++ b/nicer/sci_plots.py
@@ -131,13 +131,14 @@ def sci_plots(etable, gtitable, args):
     if len(stringtable_start)> 10:
         stringtable_start = stringtable_start[0:6] + ['...'] + stringtable_start[-3:]
         stringtable_stop = stringtable_stop[0:6] + ['...'] + stringtable_stop[-3:]
-        stringtable_duration = stringtable_duration[0:6] + ['({:9.1f})'.format(np.sum(list(map(float, stringtable_duration[7:-3]))))] + stringtable_duration[-3:]
+        # stringtable_duration = stringtable_duration[0:6] + ['({:9.1f})'.format(np.sum(list(map(float, stringtable_duration[7:-3]))))] + stringtable_duration[-3:]
+        stringtable_duration = stringtable_duration[0:6] + ['...'] + stringtable_duration[-3:]
     stringtable_start ='\n'.join(stringtable_start)
     stringtable_stop ='\n'.join(stringtable_stop)
     stringtable_duration ='\n'.join(stringtable_duration)
 
     plt.figtext(0.5, 0.77, stringtable_start, fontsize=10, fontname='Courier')
-    plt.figtext(0.58, 0.77, stringtable_stop, fontsize=10, fontname='Courier')
-    plt.figtext(0.66, 0.77, stringtable_duration, fontsize=10, fontname='Courier')
+    plt.figtext(0.62, 0.77, stringtable_stop, fontsize=10, fontname='Courier')
+    plt.figtext(0.74, 0.77, stringtable_duration, fontsize=10, fontname='Courier')
 
     return figure2

--- a/nicer/sci_plots.py
+++ b/nicer/sci_plots.py
@@ -113,6 +113,15 @@ def sci_plots(etable, gtitable, args):
     stringtable_stop = str(gtitable["STOP"][:]).split('\n')
     stringtable_duration = str(gtitable["DURATION"][:]).split('\n')
 
+    # In case the duration_table contains '...'
+    bad_durations = np.char.endswith(stringtable_duration, '...')
+    if bad_durations.any():
+        idx_to_remove = np.argwhere(bad_durations).flatten()
+        for idx in np.flip(idx_to_remove):
+            del stringtable_start[idx]
+            del stringtable_stop[idx]
+            del stringtable_duration[idx]
+
     # Bit of formatting of the duration table
     stringtable_duration[0:2] = ["  {}".format(i) for i in stringtable_duration[0:2]]
     stringtable_duration[2] = "---{}".format(stringtable_duration[2])


### PR DESCRIPTION
Fixing issue #93.
Removing items in the stringtable (start, stop, duration), when the duration contains '...'

@paulray : Can you check this ?  I cannot reproduce the error since I don't have a case where `str(gtitable["DURATION"][:]).split('\n')` produces '...'. 