### PR TITLE
Modification of output GTI list in sci_plots

### DIFF
--- a/nicer/plotutils.py
+++ b/nicer/plotutils.py
@@ -1053,3 +1053,36 @@ def filt_ratio_trumpet(etable):
 
     etable = etable[np.where(ratio < ratio_cut)[0]]
     return etable
+
+def format_gti_longstring(gticolumn, nCut=3):
+
+    gtidata = gticolumn.data
+    units = "({})".format(gticolumn.unit.name)
+
+    if gticolumn.name == 'DURATION':
+        omitted_gtis_duration = np.sum(gtidata[nCut:-nCut])
+        sumgti = "({:.1f})".format(omitted_gtis_duration)
+    else:
+        sumgti = '...'
+
+    # Find column width
+    width = max( len(str(np.max(gtidata))) + 1,
+                 len(gticolumn.name),
+                 len(sumgti))
+
+    # String header
+    string_gtidata = "{}\n{}\n{}\n".format(gticolumn.name.center(width," "),
+                                           units.center(width," "),
+                                           "_"*width)
+
+    # String body (without omitted GTIs is too many GTIs)
+    if len(gtidata) > nCut*2:
+        short_gtidata = np.delete(gtidata, np.arange(nCut,len(gtidata)-nCut,1))
+        string_gtidata += '\n'.join(["{val: {width}}".format(val=i, width=width) for i in short_gtidata[:nCut]])
+        string_gtidata += "\n{}\n".format(sumgti.rjust(width," "))
+        string_gtidata += '\n'.join(["{val: {width}}".format(val=i, width=width) for i in short_gtidata[-nCut:]])
+    else:
+        short_gtidata = gtidata
+        string_gtidata += '\n'.join(["{val: {width}}".format(val=i, width=width) for i in short_gtidata])
+
+    return string_gtidata, len(gtidata[nCut:-nCut])

--- a/nicer/sci_plots.py
+++ b/nicer/sci_plots.py
@@ -109,36 +109,15 @@ def sci_plots(etable, gtitable, args):
     if args.mask:
         plt.figtext(0.07, 0.81, "IDS {0} are masked".format(args.mask), fontsize=10)
 
-    stringtable_start = str(gtitable["START"][:]).split('\n')
-    stringtable_stop = str(gtitable["STOP"][:]).split('\n')
-    stringtable_duration = str(gtitable["DURATION"][:]).split('\n')
-
-    # In case the duration_table contains '...'
-    bad_durations = np.char.endswith(stringtable_duration, '...')
-    if bad_durations.any():
-        idx_to_remove = np.argwhere(bad_durations).flatten()
-        for idx in np.flip(idx_to_remove):
-            del stringtable_start[idx]
-            del stringtable_stop[idx]
-            del stringtable_duration[idx]
-
-    # Bit of formatting of the duration table
-    stringtable_duration[0:2] = ["  {}".format(i) for i in stringtable_duration[0:2]]
-    stringtable_duration[2] = "---{}".format(stringtable_duration[2])
-    stringtable_duration[3:] = ["  {}".format(i) for i in stringtable_duration[3:]]
-
-    # omits GTIs in the display table if there are more than 7 (the first 3 lines are for the table header)
-    if len(stringtable_start)> 10:
-        stringtable_start = stringtable_start[0:6] + ['...'] + stringtable_start[-3:]
-        stringtable_stop = stringtable_stop[0:6] + ['...'] + stringtable_stop[-3:]
-        # stringtable_duration = stringtable_duration[0:6] + ['({:9.1f})'.format(np.sum(list(map(float, stringtable_duration[7:-3]))))] + stringtable_duration[-3:]
-        stringtable_duration = stringtable_duration[0:6] + ['...'] + stringtable_duration[-3:]
-    stringtable_start ='\n'.join(stringtable_start)
-    stringtable_stop ='\n'.join(stringtable_stop)
-    stringtable_duration ='\n'.join(stringtable_duration)
+    stringtable_start, _ = format_gti_longstring(gtitable["START"], nCut=3)
+    stringtable_stop, _ = format_gti_longstring(gtitable["STOP"], nCut=3)
+    stringtable_duration, nb_omitted_gtis = format_gti_longstring(gtitable["DURATION"], nCut=3)
 
     plt.figtext(0.5, 0.77, stringtable_start, fontsize=10, fontname='Courier')
-    plt.figtext(0.62, 0.77, stringtable_stop, fontsize=10, fontname='Courier')
-    plt.figtext(0.74, 0.77, stringtable_duration, fontsize=10, fontname='Courier')
+    plt.figtext(0.58, 0.77, stringtable_stop, fontsize=10, fontname='Courier')
+    plt.figtext(0.66, 0.77, stringtable_duration, fontsize=10, fontname='Courier')
+
+    if nb_omitted_gtis>0:
+        plt.figtext(0.55, 0.75, "with {} omitted GTIS".format(nb_omitted_gtis), fontsize=10, fontname='Courier')
 
     return figure2


### PR DESCRIPTION
Extra method `format_gti_longstring()` added in `plotutils.py`, being called from `sci_plots.py` to generate the GTI list string for the display. The method now uses the entire GTI data (from `gtitable.data`) instead of `str(gtitable[column_name])` (which was returning `...` for large tables.

Output figure with small number of GTIs (i.e., no omitted GTIs)
<img width="1174" alt="Screenshot 2022-09-29 at 10 21 44" src="https://user-images.githubusercontent.com/22171129/192979738-a6884863-8785-4e63-9c4e-dfcc219cc4b1.png">

Output figure with large number of GTIs (i.e., many omitted GTIs)
<img width="695" alt="Screenshot 2022-09-29 at 10 22 09" src="https://user-images.githubusercontent.com/22171129/192979799-69065c27-6997-4131-8e39-310b37a18eed.png">
