### PR TITLE
Minor change that ensures the correct error values are written to .yml file

### DIFF
--- a/scripts/RPP-scorpeon_yml.py
+++ b/scripts/RPP-scorpeon_yml.py
@@ -149,7 +149,7 @@ for m in model_lines:
     model_names = np.append(model_names, m.split()[3].strip())
     param_names = np.append(param_names, m.split()[4].strip())
     param_vals = np.append(param_vals, m.split()[-3].strip())
-print(bbcount, plcount)
+
 # Get error values
 # Right now, using the "error" command in xspec for the errors
 # There are the same number of error_lines as model_lines

--- a/scripts/RPP-scorpeon_yml.py
+++ b/scripts/RPP-scorpeon_yml.py
@@ -73,7 +73,7 @@ for i in range(0,len(lines)):
 
 error_lines = np.array([], dtype=str)
 for i in range(error_start_ind, error_end_ind):
-    if lines[i].startswith('#     '):
+    if lines[i].startswith('#     ') and lines[i].endswith(')\n'):
         error_lines = np.append(error_lines, lines[i])
 print(error_lines)
     


### PR DESCRIPTION
The former version of this script was grabbing lines from the *final.log file containing error values from the XSPEC command "error". But if "error" finds a better-fitting value for a given parameter, XSPEC will rerun the whole fit and will start over with the "error" command. Everything is written to the log, so if you aren't careful to only grab the final set of values from "error", you will get the wrong error values. The bug fix required only a few additional lines, and I also added a detailed comment explaining what those lines are doing.